### PR TITLE
Fix dropped bytes when Read returns (n>0, io.EOF) together

### DIFF
--- a/tokenizer.go
+++ b/tokenizer.go
@@ -218,5 +218,15 @@ func (t *tokenizer) refill() (err error) {
 	t.bufp = 0
 	t.bufe, err = t.in.Read(t.buf)
 
+	// A Read may return n>0 bytes together with a non-nil error (commonly
+	// io.EOF) in a single call — this is legal per the io.Reader contract, and
+	// os.File and net/http/httptest response bodies do exactly that. Honoring
+	// the error now would discard the bytes just buffered. Defer it until the
+	// buffer is drained (the next refill re-reads and surfaces the error with
+	// n==0), mirroring how bufio.Reader behaves.
+	if t.bufe > 0 {
+		return nil
+	}
+
 	return err
 }

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -155,6 +155,63 @@ func TestToken_Bad(t *testing.T) {
 	}
 }
 
+// eofWithDataReader returns the final bytes together with io.EOF in a single
+// Read. This is legal per the io.Reader contract (os.File and
+// net/http/httptest response bodies do it) and must not cause the tokenizer to
+// drop the bytes that arrive alongside the EOF.
+type eofWithDataReader struct{ data []byte }
+
+func (r *eofWithDataReader) Read(p []byte) (int, error) {
+	n := copy(p, r.data)
+	r.data = r.data[n:]
+	if len(r.data) == 0 {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func TestToken_EOFWithData(t *testing.T) {
+	const in = `{"k1":"a loooooooooong value","k2":1234567}`
+	toks := []TokType{
+		TokObjectOpen,
+		TokString, TokObjectColon, TokString, TokComma,
+		TokString, TokObjectColon, TokNumber,
+		TokObjectClose,
+	}
+	want := []string{"k1", "a loooooooooong value", "k2", "1234567"}
+
+	// Exercise a range of buffer sizes so a refill lands mid-token on the
+	// final chunk (the case that arrives as (n>0, io.EOF)).
+	for _, size := range []int{1, 3, 7, 16, 64} {
+		t.Run(fmt.Sprintf("size=%d", size), func(t *testing.T) {
+			is := is.New(t)
+			tk := NewWithSize(&eofWithDataReader{data: []byte(in)}, size)
+
+			var got []string
+			for i := 0; i < len(toks); i++ {
+				tok, err := tk.Token()
+				is.NoErr(err)
+				is.Equal(tok, toks[i])
+				switch tok {
+				case TokString:
+					var buf bytes.Buffer
+					_, err := tk.ReadString(&buf)
+					is.NoErr(err)
+					got = append(got, buf.String())
+				case TokNumber:
+					var buf bytes.Buffer
+					_, err := tk.ReadNumber(&buf)
+					is.NoErr(err)
+					got = append(got, buf.String())
+				}
+			}
+			_, err := tk.Token()
+			is.Equal(err, io.EOF)
+			is.Equal(got, want)
+		})
+	}
+}
+
 func TestReset(t *testing.T) {
 	is := is.New(t)
 	tk := NewWithSize(bytes.NewBufferString("null"), 7)


### PR DESCRIPTION
`refill()` returns the error from `in.Read` immediately, even when that same
`Read` call also returned buffered bytes:

```go
func (t *tokenizer) refill() (err error) {
	t.bufp = 0
	t.bufe, err = t.in.Read(t.buf)
	return err
}
```

Per the [`io.Reader` contract](https://pkg.go.dev/io#Reader), a `Read` may return
`n>0` bytes **together with** a non-nil error (commonly `io.EOF`) in a single
call, and "callers should always process the `n>0` bytes returned before
considering the error." `os.File` at end-of-file and `net/http`/`httptest`
response bodies do exactly this.

`ReadString`, `ReadNumber`, and `readWord` all act on the error from `refill()`
before scanning the bytes it just buffered, so the final chunk of a token — e.g.
a string's closing `"` — is silently dropped. The result is spurious failures
like `invalid json` or `expected … got EOF` on input that is perfectly valid.

Readers that split EOF into a trailing zero-byte read (`bytes.Reader`,
`bufio.Reader`, real `net/http`) never hit the bug, which is why it shows up only
with certain readers.

## Fix

Defer the error in `refill()` until the buffer is actually drained — the next
`refill()` re-reads and surfaces the error with `n==0`. This mirrors how
`bufio.Reader` handles the same situation and fixes every caller at once:

```go
func (t *tokenizer) refill() (err error) {
	t.bufp = 0
	t.bufe, err = t.in.Read(t.buf)
	if t.bufe > 0 {
		return nil
	}
	return err
}
```

## Test

`TestToken_EOFWithData` tokenizes `{"k1":"a loooooooooong value","k2":1234567}`
through a reader that returns its final bytes together with `io.EOF`, across a
range of buffer sizes so a refill lands mid-token on the EOF chunk. It fails on
`main` (e.g. size=16 reads only 3 of 9 tokens) and passes with this change. The
existing suite is unaffected.